### PR TITLE
Fix 404 error for Open Civil Registration & Vital Statistics

### DIFF
--- a/nominees/open-civil-registration-and-vital-statistics.json
+++ b/nominees/open-civil-registration-and-vital-statistics.json
@@ -4,7 +4,7 @@
     "OpenCRVS"
   ],
   "description": "Configurable software for civil registration designed for low resource settings",
-  "website": "www.opencrvs.org",
+  "website": "https://www.opencrvs.org",
   "license": [
     {
       "spdx": "MPL-2.0",


### PR DESCRIPTION
I can see a 404 from the link to the website on https://digitalpublicgoods.net/explore/. I think we need to add ```https://``` here.