### PR TITLE
BLD: adds [skip pr] functionality

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,10 @@ jobs:
   open_pr:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: |
+      github.ref == 'refs/heads/master' &&
+      !contains(format('{0} {1} {2}', github.event.head_commit.message, github.event.pull_request.title, github.event.pull_request.body), '[skip pr]') &&
+      !contains(format('{0} {1} {2}', github.event.head_commit.message, github.event.pull_request.title, github.event.pull_request.body), '[pr skip]')
 
     steps:
       - uses: actions/checkout@v2
@@ -56,5 +59,3 @@ jobs:
           GITHUBTOKEN: ${{ secrets.GITHUBTOKEN }}
         run:
           node scripts/open_pr.js
-
-

--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ For those projects that match [the initial set of requirements](https://digitalp
 
 From the set of nominee json files, [this list](https://digitalpublicgoods.net/explore/) of Digital Global Public Goods is automatically generated and kept in sync with the contents of this repo.
 
+## Development
+
+Refer to [docs/development.md](docs/development.md) for information related to doing development with this repository.
+
 ## License
 
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,9 @@
+# Development
+
+This document contains additional information related to the development of this repo.
+
+## CI
+
+This repository relies on **GitHub Actions** for its Continuous Integration. The CI configuration can be found in [.github/workflows/main.yml](../.github/workflows/main.yml)
+
+When merging to master, the CI will automatically open a pull request (PR) against [publicgoods/products](https://github.com/publicgoods/products) to keep both repositories in sync if there are any changes to any of the JSON nominee files in `nominees/`. Include either `[skip pr]` or `[pr skip]` in either the commit message, the pull request title, or the pull request body to prevent this action from happening automatically.


### PR DESCRIPTION
Fix #54 

Include `[skip pr]` or `[pr skip]` to prevent the CI from automatically open a PR when committing/merging to master