### PR TITLE
BLD: added new field: SDGevidence [skip pr]

### DIFF
--- a/scripts/order-fields.js
+++ b/scripts/order-fields.js
@@ -23,6 +23,7 @@ const propertiesOrder = [
   "spdx",
   "licenseURL",
   "SDGs",
+  "SDGevidence",
   "sectors",
   "type",
   "repositoryURL",


### PR DESCRIPTION
In preparation for accepting automatic PR from the revised online submission available at https://digitalpublicgoods.net/submission, a new field is being added to capture the corresponding field from the form on providing evidence for the relevance of this project to the SDGs
