### PR TITLE
MAINT: name updates for OpenLMIS, OpenMRS [skip pr]

### DIFF
--- a/nominees/openlmis.json
+++ b/nominees/openlmis.json
@@ -1,8 +1,5 @@
 {
-  "name": "Open Logistics Management Information System",
-  "aliases": [
-    "OpenLMIS"
-  ],
+  "name": "OpenLMIS",
   "description": "Cloud-based electronic logistics management information system (LMIS) purpose-built to manage health commodity distribution in low- and middle-income countries.",
   "website": "https://openlmis.org",
   "license": [

--- a/nominees/openmrs-android-client.json
+++ b/nominees/openmrs-android-client.json
@@ -1,11 +1,11 @@
 {
-  "name": "Open MRS Core",
-  "description": "OpenMRS API and web application code",
+  "name": "OpenMRS Android Client",
+  "description": "OpenMRS Android client",
   "website": "",
   "license": [
     {
       "spdx": "MPL-2.0",
-      "licenseURL": "https://github.com/openmrs/openmrs-core/blob/master/LICENSE"
+      "licenseURL": "https://github.com/openmrs/openmrs-contrib-android-client/blob/master/copyright/copyright"
     }
   ],
   "SDGs": [
@@ -18,7 +18,7 @@
   "type": [
     "software"
   ],
-  "repositoryURL": "https://github.com/openmrs/openmrs-core",
+  "repositoryURL": "https://github.com/openmrs/openmrs-contrib-android-client",
   "organizations": [
     {
       "name": "Open MRS",

--- a/nominees/openmrs-core.json
+++ b/nominees/openmrs-core.json
@@ -1,11 +1,11 @@
 {
-  "name": "Open MRS Android Client",
-  "description": "OpenMRS Android client",
+  "name": "OpenMRS Core",
+  "description": "OpenMRS API and web application code",
   "website": "",
   "license": [
     {
       "spdx": "MPL-2.0",
-      "licenseURL": "https://github.com/openmrs/openmrs-contrib-android-client/blob/master/copyright/copyright"
+      "licenseURL": "https://github.com/openmrs/openmrs-core/blob/master/LICENSE"
     }
   ],
   "SDGs": [
@@ -18,7 +18,7 @@
   "type": [
     "software"
   ],
-  "repositoryURL": "https://github.com/openmrs/openmrs-contrib-android-client",
+  "repositoryURL": "https://github.com/openmrs/openmrs-core",
   "organizations": [
     {
       "name": "Open MRS",

--- a/nominees/openmrs.json
+++ b/nominees/openmrs.json
@@ -1,8 +1,5 @@
 {
-  "name": "Open Medical Record System",
-  "aliases": [
-    "OpenMRS"
-  ],
+  "name": "OpenMRS",
   "description": "Software platform and reference application which enables design of a customized medical records system with no programming knowledge.",
   "website": "https://openmrs.org",
   "license": [


### PR DESCRIPTION
As request by OpenLMIS, updating their listing to only use the short name, and removing the spelling out. 

Did the same for OpenMRS.