### PR TITLE
BLD: updated DPG stage for 4 projects

### DIFF
--- a/nominees/apache-fineract.json
+++ b/nominees/apache-fineract.json
@@ -36,5 +36,5 @@
       "org_type": "owner"
     }
   ],
-  "stage": "nominee"
+  "stage": "DPG"
 }

--- a/nominees/opencrvs.json
+++ b/nominees/opencrvs.json
@@ -31,5 +31,5 @@
       "org_type": "owner"
     }
   ],
-  "stage": "nominee"
+  "stage": "DPG"
 }

--- a/nominees/primero.json
+++ b/nominees/primero.json
@@ -38,5 +38,5 @@
       "org_type": "owner"
     }
   ],
-  "stage": "nominee"
+  "stage": "DPG"
 }

--- a/nominees/x-road.json
+++ b/nominees/x-road.json
@@ -62,5 +62,5 @@
       "org_type": "owner"
     }
   ],
-  "stage": "nominee"
+  "stage": "DPG"
 }


### PR DESCRIPTION
Updating the status of these 4 projects are recently screened Digital Public Goods (DPGs):
* Apache Fineract (#111)
* OpenCRVS (#90)
* Primero (#93)
* X-Road (#113)