### PR TITLE
Fixed typo error in screening schema

### DIFF
--- a/screening-schema.json
+++ b/screening-schema.json
@@ -475,11 +475,11 @@
       "type": "object",
       "description": "Development & deployment countries",
       "required": [
-        "developmentCounties",
+        "developmentCountries",
         "deploymentCountries"
       ],
       "properties": {
-        "developmentCounties": {
+        "developmentCountries": {
           "type": "array",
           "description": "List of countries this project was developed in.",
           "items": {

--- a/screening/apache-fineract.json
+++ b/screening/apache-fineract.json
@@ -84,7 +84,7 @@
     }
   },
   "locations": {
-    "developmentCounties": [
+    "developmentCountries": [
       "India",
       "Kenya",
       "Germany",

--- a/screening/mifos-community-app.json
+++ b/screening/mifos-community-app.json
@@ -80,7 +80,7 @@
     }
   },
   "locations": {
-    "developmentCounties": [
+    "developmentCountries": [
       "India",
       "USA",
       "Germany",

--- a/screening/opencrvs.json
+++ b/screening/opencrvs.json
@@ -90,7 +90,7 @@
     }
   },
   "locations": {
-    "developmentCounties": [
+    "developmentCountries": [
       "United Kingdom",
       "South Africa",
       "Bangladesh"

--- a/screening/openg2p.json
+++ b/screening/openg2p.json
@@ -95,7 +95,7 @@
     }
   },
   "locations": {
-    "developmentCounties": [
+    "developmentCountries": [
       "Sierra Leone"
     ],
     "deploymentCountries": [

--- a/screening/primero.json
+++ b/screening/primero.json
@@ -85,7 +85,7 @@
     }
   },
   "locations": {
-    "developmentCounties": [
+    "developmentCountries": [
       "United States"
     ],
     "deploymentCountries": [

--- a/screening/x-road.json
+++ b/screening/x-road.json
@@ -84,7 +84,7 @@
     }
   },
   "locations": {
-    "developmentCounties": [
+    "developmentCountries": [
       "Estonia",
       "Finland"
     ],


### PR DESCRIPTION
Fixed typo error in screening schema: updated field `developmentcounties` to  `developmentCountries` and cascaded changes to all projects under screening.