### PR TITLE
MAINT: add missing repoURL [skip pr]

### DIFF
--- a/nominees/wonder-tree.json
+++ b/nominees/wonder-tree.json
@@ -30,6 +30,7 @@
   "type": [
     "aimodel"
   ],
+  "repositoryURL": "https://github.com/Wonder-Tree/PoseCamera",
   "organizations": [
     {
       "name": "Wonder Tree",


### PR DESCRIPTION
Added `repositoryURL` that we missed in #127 