### PR TITLE
BUG: fix check-filenames.sh

### DIFF
--- a/scripts/check-filenames.bash
+++ b/scripts/check-filenames.bash
@@ -11,7 +11,7 @@ pushd $SELFDIR/.. > /dev/null 2>&1
 
 if [ `ls -1 ./nominees/*.json 2>/dev/null | wc -l` -gt 0 ]; then
 	for f in ./nominees/*.json; do
-		filename=`grep -Eo -m 1 '"name":.*?[^\\]",' "$f" | awk -F':' '{print $2}' | sed -e 's/"//g' -e 's/,//g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]/-/g' -e 's/---/-/g' -e 'y/āáǎàēéěèīíǐìōóǒòūúǔùüǖǘǚǜĀÁǍÀĒÉĚÈĪÍǏÌŌÓǑÒŪÚǓÙÜǕǗǙǛš/aaaaeeeeiiiioooouuuuuuuuuAAAAEEEEIIIIOOOOUUUUUUUUUs/'| tr '[:upper:]' '[:lower:]'`
+		filename=`grep -Eo -m 1 '"name":.*?[^\\]",' "$f" | awk -F':' '{st=index($0,":");print substr($0,st+1)}' | sed -e 's/"//g' -e 's/,//g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]/-/g' -e 's/---/-/g' -e 'y/āáǎàēéěèīíǐìōóǒòūúǔùüǖǘǚǜĀÁǍÀĒÉĚÈĪÍǏÌŌÓǑÒŪÚǓÙÜǕǗǙǛš/aaaaeeeeiiiioooouuuuuuuuuAAAAEEEEIIIIOOOOUUUUUUUUUs/'| tr '[:upper:]' '[:lower:]'`
 		if [ "$filename.json" = "$(basename -- "$f")" ]; then
 			echo "Filename is valid: $filename.json"
 		else


### PR DESCRIPTION
Fixes the following bug within `scripts/check-filenames.sh`:

the `awk` portion of the parsing of the JSON file for each nominee uses `:` to parse the line that contains the `name` field such as this one:
```bash
  "name": "Wikipedia",
```
which would return `"Wikipedia",` for subsequent processing by the following `sed` command.

However, when the name attribute part of the field also contains the `:` character, there was some unexpected behavior such as:
```bash
"name": "Hive: Drone Monitoring and Management System",
```
which would only return `"Hive`, instead of the expected `"Hive: Drone Monitoring and Management System"`,

This PR fixes the above bug. Refer to [this answer](https://stackoverflow.com/questions/19154996/awk-split-only-by-first-occurrence) to only use the first occurence of `:` as a separator using `awk`
