### PR TITLE
BUG: fix missing dep in #317

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -475,6 +475,11 @@
         "path-type": "^4.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     }
   },
   "dependencies": {
+    "dotenv": "^8.2.0",
     "minimist": "^1.2.3"
   }
 }


### PR DESCRIPTION
Missing package [dotenv](https://www.npmjs.com/package/dotenv) required [here](https://github.com/unicef/publicgoods-candidates/blob/8b62f1b10c31bd71064e9cab2d818a579b6ac204/scripts/api.js#L13).

The previous CI build failed for [this reason](https://github.com/unicef/publicgoods-candidates/runs/1824452824?check_suite_focus=true#step:5:10), and this PR adds the missing dependency.