### PR TITLE
MAINT: update license link [skip pr]

### DIFF
--- a/nominees/project-connect.json
+++ b/nominees/project-connect.json
@@ -5,7 +5,7 @@
   "license": [
     {
       "spdx": "BSD-3-Clause",
-      "licenseURL": "https://github.com/unicef/magicbox-maps"
+      "licenseURL": "https://github.com/unicef/magicbox-maps/blob/master/LICENSE"
     }
   ],
   "SDGs": [


### PR DESCRIPTION
The license link was not pointing to the actual LICENSE file in the repo. Fixed

The `[skip pr]` label is to skip the automatic opening of a PR to propagate these changes to `publicgoods/products` since this change has already been manually pushed there in publicgoods/products#100