### PR TITLE
Removed NLOD-1.0 license from MET Norway licensing list

### DIFF
--- a/nominee-schema.json
+++ b/nominee-schema.json
@@ -142,7 +142,6 @@
               "Naumen",
               "NCSA",
               "NGPL",
-              "NLOD-1.0",
               "Nokia",
               "NPOSL-3.0",
               "NTP",

--- a/nominees/met-norway-weather-api.json
+++ b/nominees/met-norway-weather-api.json
@@ -6,10 +6,6 @@
     {
       "spdx": "CC-BY-4.0",
       "licenseURL": "https://developer.yr.no/doc/License/"
-    },
-    {
-      "spdx": "NLOD-1.0",
-      "licenseURL": "https://api.met.no/license_data.html"
     }
   ],
   "SDGs": [


### PR DESCRIPTION
Removed `NLOD-1.0` license from `MET Norway Weather API` licensing list.