### PR TITLE
add nominee: Aleph

### DIFF
--- a/nominees/aleph.json
+++ b/nominees/aleph.json
@@ -1,0 +1,34 @@
+{
+  "name": "Aleph",
+  "description": "Aleph is a suite of data analysis tools for investigators.",
+  "website": "https://docs.alephdata.org",
+  "license": [
+    {
+      "spdx": "MIT",
+      "licenseURL": "https://github.com/alephdata/aleph/blob/main/LICENSE.txt"
+    }
+  ],
+  "SDGs": [
+    {
+      "SDGNumber": 16,
+      "evidenceText": "The goal of the Aleph project is to provide powerful technology to investigative journalists who want to track (mainly) white collar crime. The development is fully open, and coordinated by the data team at the Organized Crime and Corruption Reporting Project."
+    }
+  ],
+  "sectors": [
+    "Anti-corruption",
+    "Big Data",
+    "Democracy"
+  ],
+  "type": [
+    "software"
+  ],
+  "repositoryURL": "https://github.com/alephdata/aleph",
+  "organizations": [
+    {
+      "name": "Organized Crime and Corruption Reporting Project",
+      "website": "https://www.occrp.org/en",
+      "org_type": "owner"
+    }
+  ],
+  "stage": "nominee"
+}

--- a/nominees/aleph.json
+++ b/nominees/aleph.json
@@ -11,7 +11,7 @@
   "SDGs": [
     {
       "SDGNumber": 16,
-      "evidenceText": "The goal of the Aleph project is to provide powerful technology to investigative journalists who want to track (mainly) white collar crime. The development is fully open, and coordinated by the data team at the Organized Crime and Corruption Reporting Project."
+      "evidenceText": "The goal of the Aleph project is to provide powerful technology to investigative journalists who want to track (mainly) white collar crime. The development is fully open, and coordinated by the data team at the Organized Crime and Corruption Reporting Project. With Aleph journalists can search and cross-reference more than one billion records to trace criminal connections and patterns and efficiently collaborate across borders."
     }
   ],
   "sectors": [


### PR DESCRIPTION
The goal of the Aleph project is to provide powerful technology to investigative journalists who want to track (mainly) [white collar crime](https://en.wikipedia.org/wiki/White-collar_crime). The development is fully open, and coordinated by the data team at the Organized Crime and Corruption Reporting Project.
With Aleph journalists can search and cross-reference more than one billion records to trace criminal connections and patterns and efficiently collaborate across borders. 