### PR TITLE
Add information about debugging errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,12 +83,24 @@ You are taken to a new page where you can leave a comment about the file you are
 ### 5a. Validate your submission
 
 Wait for the green checkmark to say `All checks have passed` to have confirmation that the file complies with the expected format, and is ready to merge pending a review. 
-The automated tests that are run for all nominee files include: [JSON schema validation](/nominee-schema.json), linting (2-space indentation), 
-ensuring consistent file naming, and ensuring a consistent order in the fields of the JSON files. Refer to the [development overview](/docs/development.md#overview)
-for additional information.
+If you see that some tests fail, follow the link to the Continous Integration (CI) build, which will provide with the cause of the error. Please correct any errors until you see that all checks pass. The automated tests that are run for all nominee files and instructions to debug common errors in them are given below:
 
-If you see that the some tests fail, follow the link to the Continous Integration (CI) build, which will provide with the cause of the error. 
-Please correct any errors until you see that all checks pass
+* [JSON schema validation](/nominee-schema.json)
+  - This test ensures that all JSON files have the required fields, and each of these fields has the expected data type.
+  - The CI build will indicate in which line the error lies. Please ensure that the field names and values entered in that line align with the schema.  
+* Linting 
+  - This test ensures that there is 2-space identation and a predefined separation of fields line by line.
+  - If you are working on your local machine, run `npm run lint:fix` to automatically fix issues with linting.
+  - If you are submitting the file directly through the browser, ensure that you remove all extra spaces and the fields are separated line by line.
+* Ensuring consistent file naming
+  - This test checks that all data files are named consistely, that is by using the field name in [kebab-case](https://wiki.c2.com/?KebabCase).
+  - If this test fails, ensure that punctuation is removed and spaces are replaced by single hyphens in the name of your file. 
+* Ensuring consistent order in the fields of JSON files
+  - This test checks that the data fields in all JSON files are in a predefined order.
+  - Please ensure that all field names in your file are as per the order given in the [template](#template).
+
+Refer to the [development overview](/docs/development.md#overview) for additional information. 
+
 
 ## Template
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,17 +87,20 @@ If you see that some tests fail, follow the link to the Continous Integration (C
 
 * [JSON schema validation](/nominee-schema.json)
   - This test ensures that all JSON files have the required fields, and each of these fields has the expected data type.
-  - The CI build will indicate in which line the error lies. Please ensure that the field names and values entered in that line align with the schema.  
-* Linting 
+  - The CI build will indicate in which line the error lies. Please ensure that the field names and values entered in that line align with the schema.
+  - If you are working on your local machine, run `npm run test` to run the JSON schema validation. 
+* **Linting** 
   - This test ensures that there is 2-space identation and a predefined separation of fields line by line.
   - If you are working on your local machine, run `npm run lint:fix` to automatically fix issues with linting.
   - If you are submitting the file directly through the browser, ensure that you remove all extra spaces and the fields are separated line by line.
-* Ensuring consistent file naming
+* **Ensuring consistent file naming**
   - This test checks that all data files are named consistely, that is by using the field name in [kebab-case](https://wiki.c2.com/?KebabCase).
   - If this test fails, ensure that punctuation is removed and spaces are replaced by single hyphens in the name of your file. 
-* Ensuring consistent order in the fields of JSON files
+  - If you are working on your local machine, run `npm run check:fix` to automatically name all the files using the right convention.
+* **Ensuring consistent order in the fields of JSON files**
   - This test checks that the data fields in all JSON files are in a predefined order.
   - Please ensure that all field names in your file are as per the order given in the [template](#template).
+  - If you are working on your local machine, run `npm run order:fix` to automatically sort all the fields correctly.
 
 Refer to the [development overview](/docs/development.md#overview) for additional information. 
 


### PR DESCRIPTION
This contribution is for the open-ended issue in #473.
Initially I made a lot of errors while trying to nominate a Digital Public Good and was unable to understand the reason for the error and how to debug it. I have added some additional information in the `Validate your submission` section so that new contributors find it easier to debug if the CI build fails when they are submitting the PR.