### PR TITLE
Add links to sdg goals [skip pr]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,9 @@ Please correct any errors until you see that all checks pass
         "stage": "REQUIRED: Screening stage of Digital Public Good"
 }
 ```
+### Specifying SDGs
+
+Refer to [the UN’s 2030 Sustainable Development Goals](https://sdgs.un.org/goals) for details about each SDG. 
 
 ### Specifying Licenses
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Welcome! 👋 &nbsp;We are glad that have found this repo and you are interested in Digital Public Goods, and using technology to make this world  a more just and equitable one. We are in this together: the more, the greater impact!
 
-We define digital public goods as *open source software, open data, open AI models, open standards and open content that adhere to privacy and other applicable best practices, do no harm and are of high relevance for attainment of the UN’s 2030 Sustainable Development Goals (SDGs)*. This repository is used to manage the process of adding nominees for consideration as [Digital Global Public Goods](https://digitalpublicgoods.net/public-goods/). This is one of four interconnected repositories; refer to the [publicgoods-website](https://github.com/unicef/publicgoods-website) for an overview.
+We define digital public goods as *open source software, open data, open AI models, open standards and open content that adhere to privacy and other applicable best practices, do no harm and are of high relevance for attainment of [the UN’s 2030 Sustainable Development Goals (SDGs)](https://sdgs.un.org/goals)*. This repository is used to manage the process of adding nominees for consideration as [Digital Global Public Goods](https://digitalpublicgoods.net/public-goods/). This is one of four interconnected repositories; refer to the [publicgoods-website](https://github.com/unicef/publicgoods-website) for an overview.
 
 From the set of data files found in the `nominees/` folder, [this list](https://digitalpublicgoods.net/explore/) of Digital Global Public Goods is automatically generated and kept in sync with the contents of this repo.
 


### PR DESCRIPTION
This PR is for open ended issue in #473
I found that in current repo and site little information about what are UN's SDGs. Right now new contributors need to Google it.
I added relevant links to `sdgs.un.org/goals` in `README.md` and `CONTRIBUTING.md`. Hope it'll help)