### PR TITLE
BLD: propagating unicef/publicgoods-scripts#19

### DIFF
--- a/scripts/push.bash
+++ b/scripts/push.bash
@@ -3,18 +3,22 @@ git clone https://github.com/unicef/publicgoods-website.git ../publicgoods-websi
     git clone https://github.com/unicef/publicgoods-scripts.git ../publicgoods-scripts && \
     pushd ../publicgoods-scripts && \
         npm install && \
-        ./static.bash && \
-        node generate_dpgs.js && \
-        node index.js && \
-        node generate_nominees.js && \
-        npm run build && \
-        ./moveFiles.bash && \
+        ./scripts/static.bash && \
+        pushd packages/automation && \
+            node generate_dpgs.js && \
+            node index.js && \
+            node generate_nominees.js && \
+        popd && \
+        pushd packages/registry && \
+            npm run build && \
+        popd && \
+        ./scripts/moveFiles.bash && \
     popd && \
     git config --global user.email "lacabra@users.noreply.github.com" && \
     git config --global user.name "Victor Grau Serrat" && \
     pushd ../publicgoods-website && \
-    git remote set-url origin https://${GITHUB_TOKEN}@github.com/unicef/publicgoods-website.git && \
-    git add author blog category registry tag && \
-    git stash && git pull --rebase && git stash pop && \
-    git commit -am "BLD: $GITHUB_SHA" || true && \
-    git push --set-upstream origin master
+        git remote set-url origin https://${GITHUB_TOKEN}@github.com/unicef/publicgoods-website.git && \
+        git add author blog category registry tag && \
+        git stash && git pull --rebase && git stash pop && \
+        git commit -am "BLD: $GITHUB_SHA" || true && \
+        git push --set-upstream origin master


### PR DESCRIPTION
Connected repo [unicef/publicgoods-scripts](https://github.com/unicef/publicgoods-scripts/) switched to a monorepo structure managed through npm@7 workspaces. The folder structure and relative paths changed, so this PR propagates the changes needed so as not to break integration in the CI.