### PR TITLE
MAINT: update CI to Node v16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: Install dependecies
         run: npm install
       # - name: Run Server


### PR DESCRIPTION
Follow up to #578, fixes the CI by upgrading the version of Node to 16