### PR TITLE
BUG: update CI to Node v16

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: Install dependecies
         run: npm install
       - name: Deploy


### PR DESCRIPTION
Follow up to #580 and #578, fixes the CI by upgrading the version of Node to 16.

There are two different GitHub Actions workflows: #580 fixed the one that runs on every commit to master (`main.yml`), this PR fixes the one that runs nightly on a cronjob at midnight GMT (`auto.yml`).