### PR TITLE
MAINT: propagate unicef/publicgoods-scripts#18

### DIFF
--- a/scripts/push.bash
+++ b/scripts/push.bash
@@ -12,6 +12,9 @@ git clone https://github.com/unicef/publicgoods-website.git ../publicgoods-websi
         pushd packages/registry && \
             npm run build && \
         popd && \
+        pushd packages/eligibility && \
+            npm run build && \
+        popd && \
         ./scripts/moveFiles.bash && \
     popd && \
     git config --global user.email "lacabra@users.noreply.github.com" && \


### PR DESCRIPTION
Includes the generation of `/eligibility` page on the public website, which was introduced in unicef/publicgoods-scripts#18