### PR TITLE
MAINT: removed extra space

### DIFF
--- a/nominee-schema.json
+++ b/nominee-schema.json
@@ -147,7 +147,7 @@
               "NTP",
               "OCLC-2.0",
               "ODbL-1.0",
-              "ODC-By-1.0 ",
+              "ODC-By-1.0",
               "OFL-1.1",
               "OFL-1.1-no-RFN",
               "OFL-1.1-RFN",


### PR DESCRIPTION
Remove trailing space in license entry in `nominee-schema.js`