### PR TITLE
BUG: fix CI script, update branch name

### DIFF
--- a/scripts/push.bash
+++ b/scripts/push.bash
@@ -24,4 +24,4 @@ git clone https://github.com/unicef/publicgoods-website.git ../publicgoods-websi
         git add author blog category registry tag && \
         git stash && git pull --rebase && git stash pop && \
         git commit -am "BLD: $GITHUB_SHA" || true && \
-        git push --set-upstream origin master
+        git push --set-upstream origin main


### PR DESCRIPTION
Continues the propagation of changes started in #661, which otherwise causes the CI to fail after updating the primary branch name from `master` to `main` as per #617