### PR TITLE
Update nominee: OpenAgro to AI Agro

### DIFF
--- a/nominees/ai-agro.json
+++ b/nominees/ai-agro.json
@@ -1,5 +1,5 @@
 {
-  "name": "OpenAgro",
+  "name": "AI Agro",
   "description": "Open Source Precision Agriculture with Drones leverages a set of machine learning algorithms & computer vision developed with the goal of determining health states and relevant information for efficient management of resources of different types of crops using drone data (UAV)",
   "website": "https://rentadrone.cl/developers/precision-agriculture-maps/",
   "license": [


### PR DESCRIPTION
The name `OpenAgro` was taken, so `Rentadrone.cl` (the product owner) registered a new name: `AI Agro`