### PR TITLE
BLD: propagating changes to add map to website

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -20,4 +20,6 @@ jobs:
       - name: Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN}}
+          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
+          NEXT_PUBLIC_SHEET_ID: ${{ secrets.NEXT_PUBLIC_SHEET_ID }}
         run: ./scripts/push.bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN}}
+          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}
+          NEXT_PUBLIC_SHEET_ID: ${{ secrets.NEXT_PUBLIC_SHEET_ID }}
         run: ./scripts/push.bash
 
   # As of May 2021, this integration is disabled. Leaving it commented it out for reference.

--- a/scripts/push.bash
+++ b/scripts/push.bash
@@ -15,6 +15,9 @@ git clone https://github.com/unicef/publicgoods-website.git ../publicgoods-websi
         pushd packages/eligibility && \
             npm run build && \
         popd && \
+        pushd packages/map && \
+            npm run build && \
+        popd && \
         ./scripts/moveFiles.bash && \
     popd && \
     git config --global user.email "lacabra@users.noreply.github.com" && \


### PR DESCRIPTION
Propagating the changes for unicef/publicgoods-scripts#62 since the CI of this repo (publicgoods-candiadates) is the process that does the rebuild of the public website.

I confirm that the following two variables have been added as secrets to this repository:
* `NEXT_PUBLIC_MAPBOX_TOKEN`
* `NEXT_PUBLIC_SHEET_ID`