### PR TITLE
MAINT: force color in output of order fields script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check:fix": "./scripts/check-filenames.bash --fix",
     "lint": "for f in ./nominees/*.json ./digitalpublicgoods/*.json; do jsonlint \"$f\" > tempfile.tmp; if diff $f tempfile.tmp; then echo \"Linting of $f passed\"; else echo \"Linting of $f failed\" && exit 1; fi; done",
     "lint:fix": "for f in ./nominees/*.json ./digitalpublicgoods/*.json; do echo \"$f\"; jsonlint \"$f\" -i; echo >> \"$f\"; done",
-    "order": "node scripts/order-fields.js",
+    "order": "node scripts/order-fields.js --color=always",
     "order:fix": "node scripts/order-fields.js --fix"
   },
   "author": "",


### PR DESCRIPTION
GitHub Actions support colored output in their logs, yet, the way each command in invoked through a sub-shell using bash creates an environment that is not identified as a proper TTY, and without color support. Then, when the `order-fields.js` script relies on the `colors` package to automatically detect whether the output terminal supports colors or not, it detects it doesn't and does not produce color-enabled output. Knowing that indeed the output supports color, this PR forces the code to output color, which results in the expected output. See #734's [failed CI run](https://github.com/unicef/publicgoods-candidates/runs/3724747847) for a colored output.

#734 was opened for testing purposes only; the correct flow is:
- [X] close #734 without merging
- [ ] approve and merge this to the `main` branch
- [ ] update #716 through the button provided in the web interface, which brings that branch up to date with `main`