### PR TITLE
PATCH: broken JSON schema

### DIFF
--- a/nominees/nmf-earth
+++ b/nominees/nmf-earth
@@ -5,7 +5,7 @@
   "license": [
     {
       "spdx": "GPL-3.0",
-      "https://github.com/NMF-earth/nmf-app/blob/main/LICENSE"
+      "licenseURL": "https://github.com/NMF-earth/nmf-app/blob/main/LICENSE"
     }
   ],
   "SDGs": [


### PR DESCRIPTION
Line 8 was missing the JOSN key `licenseURL`
I discovered this while building the contacts list automation